### PR TITLE
chore: get rid of cmdstats_map (#1687)

### DIFF
--- a/src/server/command_registry.cc
+++ b/src/server/command_registry.cc
@@ -54,8 +54,7 @@ void CommandId::Invoke(CmdArgList args, ConnectionContext* cntx) const {
   uint64_t before = absl::GetCurrentTimeNanos();
   handler_(std::move(args), cntx);
   uint64_t after = absl::GetCurrentTimeNanos();
-
-  auto& ent = ServerState::tlocal()->cmd_stats_map[cntx->cid->name().data()];
+  auto& ent = command_stats_[ServerState::tlocal()->thread_index()];
   ++ent.first;
   ent.second += (after - before) / 1000;
 }
@@ -86,6 +85,12 @@ CommandRegistry::CommandRegistry() {
       LOG(ERROR) << "Invalid rename_command flag, trying to give 2 names to a command";
       exit(1);
     }
+  }
+}
+
+void CommandRegistry::Init(unsigned int thread_count) {
+  for (auto& [_, cmd] : cmd_map_) {
+    cmd.Init(thread_count);
   }
 }
 

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -2001,6 +2001,9 @@ void Service::RegisterCommands() {
   server_family_.Register(&registry_);
   cluster_family_.Register(&registry_);
 
+  // Only after all the commands are registered
+  registry_.Init(pp_.size());
+
   if (VLOG_IS_ON(1)) {
     LOG(INFO) << "Multi-key commands are: ";
     registry_.Traverse([](std::string_view key, const CI& cid) {

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -68,6 +68,10 @@ class Service : public facade::ServiceInterface {
     return registry_.Find(cmd);
   }
 
+  CommandRegistry* mutable_registry() {
+    return &registry_;
+  }
+
   facade::ErrorReply ReportUnknownCmd(std::string_view cmd_name);
 
   // Returns: the new state.

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -64,8 +64,9 @@ struct Metrics {
   bool is_master = true;
 
   facade::ConnectionStats conn_stats;
-  absl::flat_hash_map<const char*, std::pair<uint64_t, uint64_t>>
-      cmd_stats_map;  // command statistics; see ServerState
+
+  // command statistics; see CommandId.
+  std::map<std::string, std::pair<uint64_t, uint64_t>> cmd_stats_map;
 
   std::vector<ReplicaRoleInfo> replication_metrics;
 };

--- a/src/server/server_state.h
+++ b/src/server/server_state.h
@@ -205,10 +205,6 @@ class ServerState {  // public struct - to allow initialization.
 
   facade::ConnectionStats connection_stats;
 
-  absl::flat_hash_map<const char*, std::pair<uint64_t, uint64_t>> cmd_stats_map;
-  // command statistics. the pair holds {cmd_calls, cmd_sum}.
-  // IMPORTANT: assumes command names are constant literals. (the pointer is being hashed)
-
  private:
   int64_t live_transactions_ = 0;
   mi_heap_t* data_heap_;


### PR DESCRIPTION
cmdstats_map were on the hotpath and are needed only to update the command stats. Instead, I introduced the stats withing the CommandId itself that we lookup anyways. Also, it removes fragile dependency on naked command name char* pointers.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->